### PR TITLE
Update broken external link

### DIFF
--- a/js/060/js/third-party/threejs/three.js
+++ b/js/060/js/third-party/threejs/three.js
@@ -6464,7 +6464,7 @@ THREE.Math = {
 
 /**
  * Spline from Tween.js, slightly optimized (and trashed)
- * http://sole.github.com/tween.js/examples/05_spline.html
+ * https://github.com/sole/tween.js/blob/r5/examples/05_spline.html
  *
  * @author mrdoob / http://mrdoob.com/
  * @author alteredq / http://alteredqualia.com/


### PR DESCRIPTION
Updated a broken link reference that was moved from
  http://sole.github.com/tween.js/examples/05_spline.html
to 
  https://github.com/sole/tween.js/blob/r5/examples/05_spline.html